### PR TITLE
First wave of feedback

### DIFF
--- a/app/src/main/java/com/leyline/xkcd/SingleComicInfoFragment.kt
+++ b/app/src/main/java/com/leyline/xkcd/SingleComicInfoFragment.kt
@@ -1,7 +1,6 @@
 package com.leyline.xkcd
 
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -24,14 +23,11 @@ class SingleComicInfoFragment : Fragment() {
     private lateinit var transcriptTextView: TextView
     private lateinit var altTextView: TextView
 
-
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_single_comic_info, container, false)
         initView(view)
         initObservers()
-        initClickListeners()
         return view
     }
 
@@ -51,7 +47,7 @@ class SingleComicInfoFragment : Fragment() {
     private fun initObservers(){
         viewModel.uiState.observe(viewLifecycleOwner){ comicDataModel ->
             releaseNumberTextView.text = comicDataModel.num.toString()
-            releaseTitleTextView.text = comicDataModel.safe_title
+            releaseTitleTextView.text = comicDataModel.safeTitle
             releaseYearTextView.text = comicDataModel.year
             releaseMonthTextView.text = comicDataModel.month
             releaseDayTextView.text = comicDataModel.day
@@ -62,9 +58,4 @@ class SingleComicInfoFragment : Fragment() {
             altTextView.text = comicDataModel.alt
         }
     }
-
-    private fun initClickListeners(){
-
-    }
-
 }

--- a/app/src/main/java/com/leyline/xkcd/SingleComicViewFragment.kt
+++ b/app/src/main/java/com/leyline/xkcd/SingleComicViewFragment.kt
@@ -57,9 +57,7 @@ class SingleComicViewFragment : Fragment() {
 
     private fun initClickListeners() {
         firstComicTextView.setOnClickListener {
-            lifecycleScope.launch {
-                viewModel.requestFirstComic()
-            }
+            viewModel.requestFirstComic()
         }
         lastComicTextView.setOnClickListener {
             viewModel.decrementCurrentComic()
@@ -71,9 +69,7 @@ class SingleComicViewFragment : Fragment() {
             viewModel.incrementCurrentComic()
         }
         latestComicTextView.setOnClickListener {
-            lifecycleScope.launch {
-                viewModel.requestLatestComic()
-            }
+            viewModel.requestLatestComic()
         }
     }
 

--- a/app/src/main/java/com/leyline/xkcd/comic/ComicDataModel.kt
+++ b/app/src/main/java/com/leyline/xkcd/comic/ComicDataModel.kt
@@ -1,6 +1,7 @@
 package com.leyline.xkcd.comic
 
 import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -10,7 +11,8 @@ data class ComicDataModel(
     val link: String?,
     val year: String,
     val news: String?,
-    val safe_title: String,
+    @SerializedName("safe_title")
+    val safeTitle: String,
     val transcript: String,
     val alt: String,
     val img: String,

--- a/app/src/main/java/com/leyline/xkcd/util/MyApplication.kt
+++ b/app/src/main/java/com/leyline/xkcd/util/MyApplication.kt
@@ -2,7 +2,6 @@ package com.leyline.xkcd.util
 
 import android.app.Application
 import com.facebook.drawee.backends.pipeline.Fresco
-import com.leyline.xkcd.networkingModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext.startKoin

--- a/app/src/main/java/com/leyline/xkcd/util/MyModule.kt
+++ b/app/src/main/java/com/leyline/xkcd/util/MyModule.kt
@@ -1,8 +1,6 @@
-package com.leyline.xkcd
+package com.leyline.xkcd.util
 
 import com.leyline.xkcd.comic.ComicViewModel
-import com.leyline.xkcd.util.ComicApi
-import com.leyline.xkcd.util.RetrofitObject
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 

--- a/app/src/main/res/layout/fragment_single_comic_view.xml
+++ b/app/src/main/res/layout/fragment_single_comic_view.xml
@@ -14,7 +14,8 @@
         fresco:layout_constraintEnd_toEndOf="parent"
         fresco:layout_constraintStart_toStartOf="parent"
         fresco:layout_constraintTop_toTopOf="parent"
-        fresco:placeholderImage="@drawable/loading_image" />
+        fresco:placeholderImage="@drawable/loading_image"
+        fresco:actualImageScaleType="fitCenter"/>
 
     <LinearLayout
         android:id="@+id/navigation"

--- a/app/src/test/java/com/leyline/xkcd/ComicViewModelTest.kt
+++ b/app/src/test/java/com/leyline/xkcd/ComicViewModelTest.kt
@@ -89,7 +89,7 @@ class ComicViewModelTest {
         assertEquals(
             message = "Expected safe_title to be 1000 Comics",
             expected = "1000 Comics",
-            actual = model.safe_title
+            actual = model.safeTitle
         )
         assertEquals(
             message = "Expected transcript to be ",

--- a/app/src/test/java/com/leyline/xkcd/ModulesTest.kt
+++ b/app/src/test/java/com/leyline/xkcd/ModulesTest.kt
@@ -1,5 +1,6 @@
 package com.leyline.xkcd
 
+import com.leyline.xkcd.util.networkingModule
 import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest

--- a/app/src/test/java/com/leyline/xkcd/RetrofitTest.kt
+++ b/app/src/test/java/com/leyline/xkcd/RetrofitTest.kt
@@ -35,7 +35,7 @@ class RetrofitTest {
         assertTrue("First comic was expected to have an empty news", response.news == "")
         assertTrue(
             "First comic was expected to have its safe_title as follows 'Barrel - Part 1'",
-            response.safe_title == "Barrel - Part 1"
+            response.safeTitle == "Barrel - Part 1"
         )
         assertTrue(
             "First comic was expected to have a transcript as follows '[[A boy sits in a barrel which is floating in an ocean.]]\\nBoy: I wonder where I'll float next?\\n[[The barrel drifts into the distance. Nothing else can be seen.]]\\n{{Alt: Don't we all.}}\"'",
@@ -73,7 +73,7 @@ class RetrofitTest {
         assertTrue("Hundredth comic was expected to have an empty news", response.news == "")
         assertTrue(
             "Hundredth comic was expected to have its safe_title as follows 'Family Circus'",
-            response.safe_title == "Family Circus"
+            response.safeTitle == "Family Circus"
         )
         assertTrue(
             "Hundredth comic was expected to have a transcript as follow '[[Picture shows a pathway winding through trees to a sink inside a house, out to some swings and back to ths sink, out to a ball and back to the sink...]]\\nCaption: Jeffy's ongoing struggle with obsessive-compulsive disorder\\n{{alt text: This was my friend David's idea}}'",
@@ -113,7 +113,7 @@ class RetrofitTest {
         assertTrue("Thousandth comic was expected to have an empty news", response.news == "")
         assertTrue(
             "Thousandth comic was expected to have its safe_title as follows '1000 Comics'",
-            response.safe_title == "1000 Comics"
+            response.safeTitle == "1000 Comics"
         )
         assertTrue(
             "Thousandth comic was expected to have a transcript as follow '[[1000 characters, numerous of which have appeared previously in other comics, are arranged to create the number \\\"1000\\\". Two more people stand in the foreground commenting on the formation]]\\n\\nPerson 1: WOOOO!\\nPerson 2: Wow - Just 24 to go until a big round-number milestone!\\n\\n{{Title text: Thank you for making me feel less alone.}}",

--- a/app/src/test/java/com/leyline/xkcd/TestMyApplication.kt
+++ b/app/src/test/java/com/leyline/xkcd/TestMyApplication.kt
@@ -1,6 +1,7 @@
 package com.leyline.xkcd
 
 import android.app.Application
+import com.leyline.xkcd.util.networkingModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext


### PR DESCRIPTION
Removes some corpse code
adds fresco xml line to make every image fit
utilized serialized name to uphold kotlin naming conventions
moved coroutine scopes from fragment to viewmodel to better leverage viewmodels advantage